### PR TITLE
[feat] Review CRUD 구현

### DIFF
--- a/item/src/main/java/com/example/ordering_lecture/item/entity/Item.java
+++ b/item/src/main/java/com/example/ordering_lecture/item/entity/Item.java
@@ -1,5 +1,6 @@
 package com.example.ordering_lecture.item.entity;
 
+import com.example.ordering_lecture.review.entity.Review;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -8,6 +9,7 @@ import org.hibernate.annotations.CreationTimestamp;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Entity
 @Builder
@@ -41,6 +43,8 @@ public class Item {
     private boolean isBaned=false;
     @Column(nullable = false)
     private String sellerEmail;
+    @OneToMany(mappedBy = "item",fetch = FetchType.LAZY, orphanRemoval = true,cascade = CascadeType.ALL)
+    private List<Review> review;
     @CreationTimestamp
     private LocalDateTime createdTime;
 

--- a/item/src/main/java/com/example/ordering_lecture/item/service/ItemService.java
+++ b/item/src/main/java/com/example/ordering_lecture/item/service/ItemService.java
@@ -40,8 +40,9 @@ public class ItemService {
     }
 
     public void deleteItem(Long id) {
-        Item item = itemRepository.findById(id).orElseThrow();
-        item.deleteItem();
+        itemRepository.deleteById(id);
+//        Item item = itemRepository.findById(id).orElseThrow();
+//        item.deleteItem();
     }
 
     public List<ItemResponseDto> banItem(String sellerEmail){

--- a/item/src/main/java/com/example/ordering_lecture/review/controller/ReviewController.java
+++ b/item/src/main/java/com/example/ordering_lecture/review/controller/ReviewController.java
@@ -1,0 +1,54 @@
+package com.example.ordering_lecture.review.controller;
+
+import com.example.ordering_lecture.review.dto.ReviewRequestDto;
+import com.example.ordering_lecture.review.dto.ReviewUpdateDto;
+import com.example.ordering_lecture.review.service.ReviewService;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/review_server")
+public class ReviewController {
+    private final ReviewService reviewService;
+
+    public ReviewController(ReviewService reviewService) {
+        this.reviewService = reviewService;
+    }
+
+    @PostMapping("/create")
+    public Object createReview(@RequestBody ReviewRequestDto reviewRequestDto){
+        reviewService.createReview(reviewRequestDto);
+        return null;
+    }
+    // 모든 리뷰 조회
+    @GetMapping("/show_all")
+    public Object showAllReview(){
+        reviewService.showAllReview();
+        return null;
+    }
+    // 특정 아이템의 id로 리뷰 조회
+    @GetMapping("/show_item/{id}")
+    public Object showItemReviews(@PathVariable Long itemId){
+        reviewService.showItemReviews(itemId);
+        return null;
+    }
+    // 특정 사용자가 작성한 리뷰 조회
+    @GetMapping("/show_buyer/{email}")
+    public Object showBuyerReviews(@PathVariable String email){
+        reviewService.showBuyerReviews(email);
+        return null;
+    }
+    // 리뷰 id로 특정 리뷰 업데이트
+    @PatchMapping("/update/{id}")
+    public Object updateReviews(@PathVariable Long id, @RequestBody ReviewUpdateDto reviewUpdateDto){
+        reviewService.updateReview(id,reviewUpdateDto);
+        return null;
+    }
+
+    // 리뷰의 id로 특정 리뷰를 삭제
+    @DeleteMapping("/delete/{id}")
+    public Object deleteReview(@PathVariable Long id){
+        reviewService.deleteReview(id);
+        return null;
+    }
+
+}

--- a/item/src/main/java/com/example/ordering_lecture/review/dto/ReviewRequestDto.java
+++ b/item/src/main/java/com/example/ordering_lecture/review/dto/ReviewRequestDto.java
@@ -1,0 +1,26 @@
+package com.example.ordering_lecture.review.dto;
+
+import com.example.ordering_lecture.item.entity.Item;
+import com.example.ordering_lecture.review.entity.Review;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class ReviewRequestDto {
+    private byte score;
+    private String content;
+    private String buyerEmail;
+    private Long itemId;
+
+    public Review toEntity(Item item){
+        return Review.builder()
+                .score(this.score)
+                .content(this.content)
+                .buyerEmail(this.buyerEmail)
+                .item(item)
+                .build();
+    }
+}

--- a/item/src/main/java/com/example/ordering_lecture/review/dto/ReviewResponseDto.java
+++ b/item/src/main/java/com/example/ordering_lecture/review/dto/ReviewResponseDto.java
@@ -1,0 +1,29 @@
+package com.example.ordering_lecture.review.dto;
+
+import com.example.ordering_lecture.review.entity.Review;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class ReviewResponseDto {
+    private Long id;
+    private byte score;
+    private String content;
+    private String buyerEmail;
+    private Long itemId;
+
+    public static ReviewResponseDto toDto(Review review){
+        return ReviewResponseDto.builder()
+                .buyerEmail(review.getBuyerEmail())
+                .id(review.getId())
+                .itemId(review.getItem().getId())
+                .score(review.getScore())
+                .content(review.getContent())
+                .build();
+    }
+}

--- a/item/src/main/java/com/example/ordering_lecture/review/dto/ReviewUpdateDto.java
+++ b/item/src/main/java/com/example/ordering_lecture/review/dto/ReviewUpdateDto.java
@@ -1,0 +1,24 @@
+package com.example.ordering_lecture.review.dto;
+
+import com.example.ordering_lecture.review.entity.Review;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class ReviewUpdateDto {
+    private Byte score;
+    private String content;
+
+    public Review toUpdate(Review review){
+        if(score != null){
+            review.updateScore(score);
+        }
+        if(content != null){
+            review.updateContent(content);
+        }
+        return review;
+    }
+}

--- a/item/src/main/java/com/example/ordering_lecture/review/entity/Review.java
+++ b/item/src/main/java/com/example/ordering_lecture/review/entity/Review.java
@@ -1,0 +1,41 @@
+package com.example.ordering_lecture.review.entity;
+
+import com.example.ordering_lecture.item.entity.Item;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class Review {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @Column(nullable = false)
+    private byte score;
+    @Column(nullable = false)
+    private String content;
+    @Column(nullable = false)
+    private String buyerEmail;
+    @JoinColumn(name="item_id",nullable = false)
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Item item;
+    @CreationTimestamp
+    private LocalDateTime createdTime;
+
+    public void updateScore(byte score){
+        this.score = score;
+    }
+    public void updateContent(String content){
+        this.content = content;
+    }
+
+}

--- a/item/src/main/java/com/example/ordering_lecture/review/repository/ReviewRepository.java
+++ b/item/src/main/java/com/example/ordering_lecture/review/repository/ReviewRepository.java
@@ -1,0 +1,15 @@
+package com.example.ordering_lecture.review.repository;
+
+import com.example.ordering_lecture.review.entity.Review;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface ReviewRepository  extends JpaRepository<Review,Long> {
+
+    List<Review> findAllByItemId(Long itemId);
+
+    List<Review> findAllByBuyerEmail(String email);
+}

--- a/item/src/main/java/com/example/ordering_lecture/review/service/ReviewService.java
+++ b/item/src/main/java/com/example/ordering_lecture/review/service/ReviewService.java
@@ -1,0 +1,63 @@
+package com.example.ordering_lecture.review.service;
+
+import com.example.ordering_lecture.item.entity.Item;
+import com.example.ordering_lecture.item.repository.ItemRepository;
+import com.example.ordering_lecture.review.dto.ReviewRequestDto;
+import com.example.ordering_lecture.review.dto.ReviewResponseDto;
+import com.example.ordering_lecture.review.dto.ReviewUpdateDto;
+import com.example.ordering_lecture.review.entity.Review;
+import com.example.ordering_lecture.review.repository.ReviewRepository;
+import org.springframework.stereotype.Service;
+
+import javax.transaction.Transactional;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class ReviewService {
+    private final ReviewRepository reviewRepository;
+    private final ItemRepository itemRepository;
+
+    public ReviewService(ReviewRepository reviewRepository, ItemRepository itemRepository) {
+        this.reviewRepository = reviewRepository;
+        this.itemRepository = itemRepository;
+    }
+
+    public Object createReview(ReviewRequestDto reviewRequestDto) {
+        //TODO : 에러 코드 추후 수정
+        Item item = itemRepository.findById(reviewRequestDto.getItemId()).orElseThrow();
+        Review review = reviewRequestDto.toEntity(item);
+        reviewRepository.save(review);
+        return ReviewResponseDto.toDto(review);
+    }
+
+    public Object showAllReview() {
+        List<Review> reviews = reviewRepository.findAll();
+        return reviews.stream()
+                .map(ReviewResponseDto::toDto)
+                .collect(Collectors.toList());
+    }
+
+    public Object showItemReviews(Long itemId) {
+        List<Review> reviews = reviewRepository.findAllByItemId(itemId);
+        return reviews.stream()
+                .map(ReviewResponseDto::toDto)
+                .collect(Collectors.toList());
+    }
+    public Object showBuyerReviews(String email) {
+        List<Review> reviews = reviewRepository.findAllByBuyerEmail(email);
+        return reviews.stream()
+                .map(ReviewResponseDto::toDto)
+                .collect(Collectors.toList());
+    }
+    public void deleteReview(Long id) {
+        reviewRepository.deleteById(id);
+    }
+
+    @Transactional
+    public ReviewResponseDto updateReview(Long id, ReviewUpdateDto reviewUpdateDto) {
+        Review review = reviewRepository.findById(id).orElseThrow();
+        reviewUpdateDto.toUpdate(review);
+        return ReviewResponseDto.toDto(review);
+    }
+}


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)

- [x] 기능 추가
- [ ] 리뷰 반영
- [x] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)

- 리뷰 CRUD를 구현 했습니다. 

<br />

1. review의 FK가 걸린 Item에 cascade를 걸어서 item 삭제 시 해당 item의 모든 review가 삭제되도록 하였습니다.

2. review의 수정 api에서 구매자 구매한 item에 대한 정보는 수정하는 경우가 없다 생각해서, 점수와 내용만 수정이 가능하도록 구현했습니다. 

<br />

- 사용자가 발생시킬 수 있는 다양한 예외 케이스에 대해 고민하게 되었습니다. (예시)
- 문자열 데이터 입력 시 마지막에 빈 문자열이 포함되어 있는 경우 데이터 처리가 올바르게 되지 않아 유효성 검사에 빈 문자열 제거하는 로직을 추가하였습니다. (예시)

<br />

- content 가 사진을 포함한 text인데 이걸 어떻게 처리 해야할지 대 고 민입니다.
