### PR TITLE
[feat] CSV파일 방식에서 DB 추출 방식으로 변경

### DIFF
--- a/recommendation/build.gradle
+++ b/recommendation/build.gradle
@@ -30,7 +30,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	compileOnly 'org.projectlombok:lombok'
-	runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
+	implementation 'org.mariadb.jdbc:mariadb-java-client:2.7.3'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	// csv 추출을 위한 의존성

--- a/recommendation/src/main/java/com/example/ordering_lecture/common/ErrorCode.java
+++ b/recommendation/src/main/java/com/example/ordering_lecture/common/ErrorCode.java
@@ -8,7 +8,11 @@ import javax.validation.constraints.NotNull;
 public enum ErrorCode {
     NOT_FOUND_FILE("R1","해당 파일을 찾을 수 없습니다."),
     NOT_MAKE_SIMILARITY("R2","유사도를 구할 수 없습니다."),
-    NOT_MAKE_TASTE("R3","추천 아이템을 구할 수 없습니다.");
+    NOT_MAKE_TASTE("R3","추천 아이템을 구할 수 없습니다."),
+    NOT_SET_URL("R4","DB 경로를 설정할 수 없습니다."),
+    NOT_SET_USER("R5","DB 유저 정보를 설정할 수 없습니다."),
+    NOT_SET_PASSWORD("R6","DB 비밀번호 정보를 설정할 수 없습니다.");
+
 
     private final String code;
     private final String message;

--- a/recommendation/src/main/java/com/example/ordering_lecture/recommend/controller/RecommendationController.java
+++ b/recommendation/src/main/java/com/example/ordering_lecture/recommend/controller/RecommendationController.java
@@ -19,11 +19,6 @@ public class RecommendationController {
         this.recommendationService = recommendationService;
     }
 
-    @GetMapping("/export-csv")
-    public String exportCSV() {
-        return recommendationService.exportDataToCsv();
-    }
-
     @GetMapping("/member/{id}/recommendations")
     public ResponseEntity<OrTopiaResponse> recommendations(@PathVariable Long id){
         List<RecommendedItem> recommendations = recommendationService.getRecommendations(id);

--- a/recommendation/src/main/java/com/example/ordering_lecture/review/entity/Review.java
+++ b/recommendation/src/main/java/com/example/ordering_lecture/review/entity/Review.java
@@ -28,14 +28,8 @@ public class Review {
     @JoinColumn(name="item_id",nullable = false)
     @ManyToOne(fetch = FetchType.LAZY)
     private Item item;
+    @Column(nullable = false)
+    private Long itemId;
     @CreationTimestamp
     private LocalDateTime createdTime;
-
-    public void updateScore(byte score){
-        this.score = score;
-    }
-    public void updateContent(String content){
-        this.content = content;
-    }
-
 }

--- a/recommendation/src/main/resources/application.yml
+++ b/recommendation/src/main/resources/application.yml
@@ -3,12 +3,9 @@ server:
 spring:
   datasource:
     driver-class-name: org.mariadb.jdbc.Driver
-    url: jdbc:mariadb://localhost:3306/item_server
+    url: jdbc:mariadb://localhost:3306/recommendation
     username: root
     password: 1234
-##    유레카 서버에 아래 application name으로 서비스명을 등록.
-#  application:
-#    name: item
   jpa:
     database: mysql
     database-platform: org.hibernate.dialect.MariaDBDialect
@@ -16,10 +13,3 @@ spring:
     hibernate:
       ddl-auto: update
     show_sql: true
-#eureka:
-#  client:
-#    serviceUrl:
-#      defaultZone: http://localhost:8761/eureka/
-#  instance:
-#    preferIpAddress: true
-#    hostname: localhost


### PR DESCRIPTION
## :: 최근 작업 주제

- [x] 기능 추가
- [ ] 리뷰 반영
- [x] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표
- DataModel 생성 시, FileDataModel 방식에서  MySQLJDBCDataModel 방식으로 변경

<br />

## :: 구현 사항 설명
![DataSource](https://github.com/yujeong-shin/OrTopia/assets/57553339/2c3b698d-74f4-45f2-bea3-86ec19e6e9ab)
MySQLJDBCDataModel 내부 코드를 보면, user_id, item_id, preferecne 세 컬럼으로 구성된 테이블이 존재한다.

1. DB review 테이블에서 user_id, item_id, preferecne에 해당하는 속성을 뽑아온다.
![DataSource2](https://github.com/yujeong-shin/OrTopia/assets/57553339/b7245073-dedd-49fe-baa5-d36e739cca6a)

3. 이후 추천 알고리즘은 동일

<br />

## :: Issue 포인트 
- implementation 'org.mariadb.jdbc:mariadb-java-client:3.3.3' 방식을 사용했지만, invalid fetch size 에러가 발생
- 이는 MariaDB Connector/J 3.x.x 버전과 관련된 설정 문제로, 2.7.3 버전으로 다운그레이드하면서 문제 해결
- 레퍼런스가 너무 없어서 내부 구현 코드를 뜯어가며 완성해서 너무 뿌듯합니더 😎

<br />
