### PR TITLE
feat : item 옵션 관련 기능 구현.

### DIFF
--- a/item/src/main/java/com/example/ordering_lecture/common/ErrorCode.java
+++ b/item/src/main/java/com/example/ordering_lecture/common/ErrorCode.java
@@ -23,7 +23,8 @@ public enum ErrorCode {
     NOT_FOUND_REVIEW("I15","해당 리뷰를 찾을 수 없습니다."),
     REDIS_ERROR("I16","레디스 저장에 실패했습니다"),
     JSON_PARSE_ERROR("I17","JSON 형변환에 실패했습니다"),
-    S3_SERVER_ERROR("I18","이미지 저장에 실패했습니다.");
+    S3_SERVER_ERROR("I18","이미지 저장에 실패했습니다."),
+    NOT_FOUND_OPTION("I19","해당 옵션의 아이템이 없습니다.");
 
     private final String code;
     private final String message;

--- a/item/src/main/java/com/example/ordering_lecture/item/controller/ItemController.java
+++ b/item/src/main/java/com/example/ordering_lecture/item/controller/ItemController.java
@@ -1,10 +1,7 @@
 package com.example.ordering_lecture.item.controller;
 
 import com.example.ordering_lecture.common.OrTopiaResponse;
-import com.example.ordering_lecture.item.dto.ItemRequestDto;
-import com.example.ordering_lecture.item.dto.ItemResponseDto;
-import com.example.ordering_lecture.item.dto.ItemUpdateDto;
-import com.example.ordering_lecture.item.dto.RecommendedItemDto;
+import com.example.ordering_lecture.item.dto.*;
 import com.example.ordering_lecture.item.service.ItemService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -23,8 +20,8 @@ public class ItemController {
     }
 
     @PostMapping("/create")
-    public ResponseEntity<OrTopiaResponse> createItem(@Valid @ModelAttribute ItemRequestDto itemRequestDto, @RequestHeader("myEmail") String email){
-        ItemResponseDto itemResponseDto = itemService.createItem(itemRequestDto,email);
+    public ResponseEntity<OrTopiaResponse> createItem(@Valid @ModelAttribute ItemRequestDto itemRequestDto, @RequestPart(name="optionList")List<OptionRequestDto> optionRequestDtos, @RequestHeader("myEmail") String email){
+        ItemResponseDto itemResponseDto = itemService.createItem(itemRequestDto,optionRequestDtos,email);
         OrTopiaResponse orTopiaResponse = new OrTopiaResponse("create success",itemResponseDto);
         return new ResponseEntity<>(orTopiaResponse,HttpStatus.CREATED);
     }
@@ -93,5 +90,10 @@ public class ItemController {
         List<RecommendedItemDto> recommendedItemDtos = itemService.findRecommendItem(email);
         OrTopiaResponse orTopiaResponse = new OrTopiaResponse("read success",recommendedItemDtos);
         return new ResponseEntity<>(orTopiaResponse,HttpStatus.OK);
+    }
+    // 조건에 맞는 item의 itemOptionQuantityId를 찾아오는 api
+    @PostMapping("/search/optionDetailId/{itemId}")
+    Long searchIdByOptionDetail(@PathVariable Long itemId,@RequestBody List<String> values){
+       return itemService.searchIdByOptionDetail(itemId,values);
     }
 }

--- a/item/src/main/java/com/example/ordering_lecture/item/dto/ItemOptionQuantityDto.java
+++ b/item/src/main/java/com/example/ordering_lecture/item/dto/ItemOptionQuantityDto.java
@@ -1,0 +1,37 @@
+package com.example.ordering_lecture.item.dto;
+
+import com.example.ordering_lecture.item.entity.Item;
+import com.example.ordering_lecture.item.entity.ItemOptionQuantity;
+import lombok.Data;
+
+@Data
+public class ItemOptionQuantityDto {
+    private String value1;
+    private String value2;
+    private String value3;
+
+    public ItemOptionQuantityDto(){
+        value1 = "NONE";
+        value2 = "NONE";
+        value3 = "NONE";
+    }
+    public void setValue(int index,String value){
+        if(index==0){
+            value1 = value;
+        }else if(index ==1){
+            value2 = value;
+        }else{
+            value3 = value;
+        }
+    }
+
+    public ItemOptionQuantity toEntity(Item item) {
+        return ItemOptionQuantity.builder()
+                .quantity(item.getStock())
+                .item(item)
+                .value1(value1)
+                .value2(value2)
+                .value3(value3)
+                .build();
+    }
+}

--- a/item/src/main/java/com/example/ordering_lecture/item/dto/ItemOptionResponseDto.java
+++ b/item/src/main/java/com/example/ordering_lecture/item/dto/ItemOptionResponseDto.java
@@ -1,0 +1,22 @@
+package com.example.ordering_lecture.item.dto;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Data
+@Builder
+@AllArgsConstructor
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
+public class ItemOptionResponseDto {
+    private String name;
+    private List<String> value;
+    public ItemOptionResponseDto(){
+        value = new ArrayList<>();
+    }
+}

--- a/item/src/main/java/com/example/ordering_lecture/item/dto/ItemResponseDto.java
+++ b/item/src/main/java/com/example/ordering_lecture/item/dto/ItemResponseDto.java
@@ -8,6 +8,8 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Data
 @Builder
@@ -26,7 +28,9 @@ public class ItemResponseDto {
     private boolean delYN;
     private boolean isBaned;
     private Long sellerId;
+    private List<ItemOptionResponseDto> itemOptionResponseDtoList;
     private String createdTime;
+
 
     public static ItemResponseDto toDto(Item item){
         return ItemResponseDto.builder()
@@ -42,6 +46,7 @@ public class ItemResponseDto {
                 .isBaned(item.isBaned())
                 .stock(item.getStock())
                 .createdTime(item.getCreatedTime().toString())
+                .itemOptionResponseDtoList(new ArrayList<>())
                 .build();
     }
 }

--- a/item/src/main/java/com/example/ordering_lecture/item/dto/OptionRequestDto.java
+++ b/item/src/main/java/com/example/ordering_lecture/item/dto/OptionRequestDto.java
@@ -1,0 +1,15 @@
+package com.example.ordering_lecture.item.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class OptionRequestDto {
+    private String optionName;
+    private List<String> details;
+}

--- a/item/src/main/java/com/example/ordering_lecture/item/entity/ItemOption.java
+++ b/item/src/main/java/com/example/ordering_lecture/item/entity/ItemOption.java
@@ -1,0 +1,24 @@
+package com.example.ordering_lecture.item.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Entity
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ItemOption {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @Column(nullable = false)
+    private String name;
+    @JoinColumn(name="item_id",nullable = false)
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Item item;
+}

--- a/item/src/main/java/com/example/ordering_lecture/item/entity/ItemOptionDetail.java
+++ b/item/src/main/java/com/example/ordering_lecture/item/entity/ItemOptionDetail.java
@@ -1,0 +1,24 @@
+package com.example.ordering_lecture.item.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Entity
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ItemOptionDetail {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @Column(nullable = false)
+    private String value;
+    @JoinColumn(name="item_option_id",nullable = false)
+    @ManyToOne(fetch = FetchType.LAZY)
+    private ItemOption itemOption;
+}

--- a/item/src/main/java/com/example/ordering_lecture/item/entity/ItemOptionQuantity.java
+++ b/item/src/main/java/com/example/ordering_lecture/item/entity/ItemOptionQuantity.java
@@ -1,0 +1,30 @@
+package com.example.ordering_lecture.item.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Entity
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ItemOptionQuantity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @Column
+    private String value1;
+    @Column
+    private String value2;
+    @Column
+    private String value3;
+    @Column
+    private int quantity;
+    @JoinColumn(name="item_id",nullable = false)
+    @ManyToOne(fetch = FetchType.EAGER)
+    private Item item;
+}

--- a/item/src/main/java/com/example/ordering_lecture/item/repository/ItemOptionDetailRepository.java
+++ b/item/src/main/java/com/example/ordering_lecture/item/repository/ItemOptionDetailRepository.java
@@ -1,0 +1,12 @@
+package com.example.ordering_lecture.item.repository;
+
+import com.example.ordering_lecture.item.entity.ItemOptionDetail;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface ItemOptionDetailRepository extends JpaRepository<ItemOptionDetail,Long> {
+    List<ItemOptionDetail> findAllByItemOptionId(Long id);
+}

--- a/item/src/main/java/com/example/ordering_lecture/item/repository/ItemOptionQuantityRepository.java
+++ b/item/src/main/java/com/example/ordering_lecture/item/repository/ItemOptionQuantityRepository.java
@@ -1,0 +1,20 @@
+package com.example.ordering_lecture.item.repository;
+
+import com.example.ordering_lecture.item.entity.ItemOptionQuantity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface ItemOptionQuantityRepository extends JpaRepository<ItemOptionQuantity, Long> {
+    @Query("SELECT ioq FROM ItemOptionQuantity ioq WHERE ioq.item.id = :itemId AND ioq.value1 = :value1 AND ioq.value2 = :value2 AND ioq.value3 = :value3")
+    Optional<ItemOptionQuantity> findItemOptionQuantity(
+            @Param("itemId") Long itemId,
+            @Param("value1") String value1,
+            @Param("value2") String value2,
+            @Param("value3") String value3
+    );
+}

--- a/item/src/main/java/com/example/ordering_lecture/item/repository/ItemOptionRepository.java
+++ b/item/src/main/java/com/example/ordering_lecture/item/repository/ItemOptionRepository.java
@@ -1,0 +1,13 @@
+package com.example.ordering_lecture.item.repository;
+
+import com.example.ordering_lecture.item.entity.ItemOption;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface ItemOptionRepository  extends JpaRepository<ItemOption,Long> {
+    List<ItemOption> findAllByItemId(Long id);
+
+}

--- a/item/src/main/java/com/example/ordering_lecture/item/service/ItemService.java
+++ b/item/src/main/java/com/example/ordering_lecture/item/service/ItemService.java
@@ -6,11 +6,14 @@ import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.example.ordering_lecture.common.ErrorCode;
 import com.example.ordering_lecture.common.OrTopiaException;
 import com.example.ordering_lecture.item.controller.MemberServiceClient;
-import com.example.ordering_lecture.item.dto.ItemRequestDto;
-import com.example.ordering_lecture.item.dto.ItemResponseDto;
-import com.example.ordering_lecture.item.dto.ItemUpdateDto;
-import com.example.ordering_lecture.item.dto.RecommendedItemDto;
+import com.example.ordering_lecture.item.dto.*;
 import com.example.ordering_lecture.item.entity.Item;
+import com.example.ordering_lecture.item.entity.ItemOption;
+import com.example.ordering_lecture.item.entity.ItemOptionDetail;
+import com.example.ordering_lecture.item.entity.ItemOptionQuantity;
+import com.example.ordering_lecture.item.repository.ItemOptionDetailRepository;
+import com.example.ordering_lecture.item.repository.ItemOptionQuantityRepository;
+import com.example.ordering_lecture.item.repository.ItemOptionRepository;
 import com.example.ordering_lecture.item.repository.ItemRepository;
 import com.example.ordering_lecture.redis.RedisService;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -33,16 +36,22 @@ public class ItemService {
     private final RedisService redisService;
     private final AmazonS3Client amazonS3Client;
     private final MemberServiceClient memberServiceClient;
-    public ItemService(ItemRepository itemRepository, RedisService redisService, AmazonS3Client amazonS3Client, MemberServiceClient memberServiceClient) {
+    private final ItemOptionDetailRepository itemOptionDetailRepository;
+    private final ItemOptionRepository itemOptionRepository;
+    private final ItemOptionQuantityRepository itemOptionQuantityRepository;
+    public ItemService(ItemRepository itemRepository, RedisService redisService, AmazonS3Client amazonS3Client, MemberServiceClient memberServiceClient, ItemOptionDetailRepository itemOptionDetailRepository, ItemOptionRepository itemOptionRepository, ItemOptionQuantityRepository itemOptionQuantityRepository) {
         this.itemRepository = itemRepository;
         this.redisService = redisService;
         this.amazonS3Client = amazonS3Client;
         this.memberServiceClient = memberServiceClient;
+        this.itemOptionDetailRepository = itemOptionDetailRepository;
+        this.itemOptionRepository = itemOptionRepository;
+        this.itemOptionQuantityRepository = itemOptionQuantityRepository;
     }
     @Value("${cloud.aws.s3.bucket}")
     private String bucket;
 
-    public ItemResponseDto createItem(ItemRequestDto itemRequestDto, String email) throws OrTopiaException {
+    public ItemResponseDto createItem(ItemRequestDto itemRequestDto,List<OptionRequestDto> optionRequestDtos ,String email) throws OrTopiaException {
         String fileName = itemRequestDto.getName() + System.currentTimeMillis();
         String fileUrl = null;
         try {
@@ -54,14 +63,61 @@ public class ItemService {
             Long sellerId = memberServiceClient.searchIdByEmail(email);
             Item item = itemRequestDto.toEntity(fileUrl, sellerId);
             itemRepository.save(item);
-            //재고를 레디스에 저장
-            redisService.setItemQuantity(item.getId(),item.getStock());
+            // 옵션이 존재하는 경우
+            if(!optionRequestDtos.isEmpty()){
+                List<List<String>> allOptionValue = new ArrayList<>();
+                int index = 0;
+                for(OptionRequestDto optionRequestDto :optionRequestDtos){
+                    allOptionValue.add(new ArrayList<>());
+                    ItemOption itemOption = ItemOption.builder()
+                            .name(optionRequestDto.getOptionName())
+                            .item(item)
+                            .build();
+                    itemOptionRepository.save(itemOption);
+                    for(String value:optionRequestDto.getDetails()){
+                        ItemOptionDetail itemOptionDetail = ItemOptionDetail.builder()
+                                .itemOption(itemOption)
+                                // 옵션의 이름
+                                .value(value)
+                                .build();
+                        allOptionValue.get(index).add(value);
+                        itemOptionDetailRepository.save(itemOptionDetail);
+                    }
+                    index++;
+                }
+                fillAllOption(item,allOptionValue,new ArrayList<>(),allOptionValue.size(),0);
+            }else{
+                ItemOptionQuantityDto itemOptionQuantityDto = new ItemOptionQuantityDto();
+                ItemOptionQuantity itemOptionQuantity = itemOptionQuantityDto.toEntity(item);
+                itemOptionQuantityRepository.save(itemOptionQuantity);
+                //재고를 레디스에 저장
+                redisService.setItemQuantity(itemOptionQuantity.getId(),item.getStock());
+            }
             return ItemResponseDto.toDto(item);
         } catch (Exception e) {
+            e.printStackTrace();
             throw new OrTopiaException(ErrorCode.S3_SERVER_ERROR);
         }
     }
 
+    // 받아온 옵션의 모든 경우의 수를 계산하여 DB에 저장.
+    public void fillAllOption(Item item, List<List<String>> allOptionValue,List<String> nowOption,int maxDepth,int nowDepth){
+        if(maxDepth == nowDepth){
+            ItemOptionQuantityDto itemOptionQuantityDto = new ItemOptionQuantityDto();
+            for(int i=0;i<nowDepth;i++){
+                itemOptionQuantityDto.setValue(i,nowOption.get(i));
+            }
+            ItemOptionQuantity itemOptionQuantity = itemOptionQuantityDto.toEntity(item);
+            itemOptionQuantityRepository.save(itemOptionQuantity);
+            redisService.setItemQuantity(itemOptionQuantity.getId(),item.getStock());
+            return;
+        }
+        for(String option : allOptionValue.get(nowDepth)){
+            nowOption.add(option);
+            fillAllOption(item,allOptionValue,nowOption,maxDepth,nowDepth+1);
+            nowOption.remove(nowOption.size()-1);
+        }
+    }
 
     public List<ItemResponseDto> showAllItem(){
         return itemRepository.findAll().stream()
@@ -150,7 +206,21 @@ public class ItemService {
                 ()->new OrTopiaException(ErrorCode.NOT_FOUND_ITEM)
                 );
         ItemResponseDto itemResponseDto = ItemResponseDto.toDto(item);
+        // 최근본 상품을 저장하기 위함
         redisService.setValues(email,itemResponseDto);
+        // 옵션을 불러옴
+        List<ItemOption> itemOptions = itemOptionRepository.findAllByItemId(id);
+        if(!itemOptions.isEmpty()){
+            for(ItemOption itemOption : itemOptions){
+                ItemOptionResponseDto itemOptionResponseDto = new ItemOptionResponseDto();
+                itemOptionResponseDto.setName(itemOption.getName());
+                List<ItemOptionDetail> itemOptionDetails = itemOptionDetailRepository.findAllByItemOptionId(itemOption.getId());
+                for(ItemOptionDetail itemOptionDetail : itemOptionDetails){
+                    itemOptionResponseDto.getValue().add(itemOptionDetail.getValue());
+                }
+                itemResponseDto.getItemOptionResponseDtoList().add(itemOptionResponseDto);
+            }
+        }
         return itemResponseDto;
     }
 
@@ -190,5 +260,27 @@ public class ItemService {
             recommendationRedisDatas.add(recommendationRedisData);
         }
         return recommendationRedisDatas;
+    }
+
+    public Long searchIdByOptionDetail(Long itemId, List<String> values) {
+        String value1 = "NONE";
+        String value2 = "NONE";
+        String value3 = "NONE";
+        if(values.size()==1){
+            value1 = values.get(0);
+        }
+        if(values.size()==2){
+            value1 = values.get(0);
+            value2 = values.get(1);
+        }
+        if(values.size()==3){
+            value1 = values.get(0);
+            value2 = values.get(1);
+            value3 = values.get(2);
+        }
+        ItemOptionQuantity itemOptionQuantity = itemOptionQuantityRepository.findItemOptionQuantity(itemId,value1,value2,value3).orElseThrow(
+                () -> new OrTopiaException(ErrorCode.NOT_FOUND_OPTION)
+        );
+        return itemOptionQuantity.getId();
     }
 }

--- a/order/build.gradle
+++ b/order/build.gradle
@@ -35,6 +35,7 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign:4.0.3'
 }
 
 dependencyManagement{

--- a/order/src/main/java/com/example/ordering_lecture/OrderingApplication.java
+++ b/order/src/main/java/com/example/ordering_lecture/OrderingApplication.java
@@ -3,9 +3,11 @@ package com.example.ordering_lecture;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.netflix.eureka.EnableEurekaClient;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 
 @SpringBootApplication
 @EnableEurekaClient
+@EnableFeignClients
 public class OrderingApplication {
 
 	public static void main(String[] args) {

--- a/order/src/main/java/com/example/ordering_lecture/payment/controller/ItemServiceClient.java
+++ b/order/src/main/java/com/example/ordering_lecture/payment/controller/ItemServiceClient.java
@@ -1,0 +1,15 @@
+package com.example.ordering_lecture.payment.controller;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+import java.util.List;
+
+@FeignClient(name = "item-service")
+public interface ItemServiceClient {
+    @PostMapping("item/search/optionDetailId/{itemId}")
+    Long searchIdByOptionDetail(@PathVariable(name = "itemId") Long itemId,@RequestBody List<String> values);
+}

--- a/order/src/main/java/com/example/ordering_lecture/payment/dto/ItemDto.java
+++ b/order/src/main/java/com/example/ordering_lecture/payment/dto/ItemDto.java
@@ -2,9 +2,12 @@ package com.example.ordering_lecture.payment.dto;
 
 import lombok.Data;
 
+import java.util.List;
+
 @Data
 public class ItemDto {
     private Long id;
     private String name;
     private int count;
+    private List<ItemOptionDto> options;
 }

--- a/order/src/main/java/com/example/ordering_lecture/payment/dto/ItemOptionDto.java
+++ b/order/src/main/java/com/example/ordering_lecture/payment/dto/ItemOptionDto.java
@@ -1,0 +1,9 @@
+package com.example.ordering_lecture.payment.dto;
+
+import lombok.Data;
+
+@Data
+public class ItemOptionDto {
+    private String name;
+    private String value;
+}

--- a/order/src/main/java/com/example/ordering_lecture/payment/service/PaymentService.java
+++ b/order/src/main/java/com/example/ordering_lecture/payment/service/PaymentService.java
@@ -2,10 +2,8 @@ package com.example.ordering_lecture.payment.service;
 
 import com.example.ordering_lecture.common.ErrorCode;
 import com.example.ordering_lecture.common.OrTopiaException;
-import com.example.ordering_lecture.payment.dto.ItemDto;
-import com.example.ordering_lecture.payment.dto.PayApproveResDto;
-import com.example.ordering_lecture.payment.dto.PayInfoDto;
-import com.example.ordering_lecture.payment.dto.PayReadyResDto;
+import com.example.ordering_lecture.payment.controller.ItemServiceClient;
+import com.example.ordering_lecture.payment.dto.*;
 import com.example.ordering_lecture.payment.request.MakePayRequest;
 import com.example.ordering_lecture.payment.request.PayRequest;
 import com.example.ordering_lecture.redis.RedisService;
@@ -20,6 +18,8 @@ import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
 
 import javax.transaction.Transactional;
+import java.util.ArrayList;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -27,6 +27,7 @@ public class PaymentService {
 
     private final MakePayRequest makePayRequest;
     private final RedisService redisService;
+    private final ItemServiceClient itemServiceClient;
 
     @Value("${pay.admin-key}")
     private String adminKey;
@@ -38,14 +39,27 @@ public class PaymentService {
     public PayReadyResDto getRedirectUrl(String email,PayInfoDto payInfoDto){
         HttpHeaders headers=new HttpHeaders();
         //아이템의 재고를 레디스로 확인
-        for(ItemDto itemDto : payInfoDto.getItemDtoList()){
-            int nowStock = redisService.getValuesItemCount(itemDto.getId());
-            if(nowStock-itemDto.getCount()<0){
-                throw new OrTopiaException(ErrorCode.ITEM_QUANTITY_ERROR);
+        for(ItemDto itemDto:payInfoDto.getItemDtoList()){
+            Long id = null;
+            //옵션이 없는 경우 체킹
+            if(!itemDto.getOptions().isEmpty()) {
+                List<String> values = new ArrayList<>();
+                for (ItemOptionDto itemOptionDto : itemDto.getOptions()) {
+                    values.add(itemOptionDto.getValue());
+                }
+                //value와 Item 아이디를 가지고 ItemOptionDetailQuantity 를 찾아와야해.
+                id = itemServiceClient.searchIdByOptionDetail(itemDto.getId(), values);
             }else{
-                // 아이템의 재고를 업데이트;
-                redisService.setItemQuantity(itemDto.getId(),nowStock-itemDto.getCount());
+                List<String> values = new ArrayList<>();
+                id = itemServiceClient.searchIdByOptionDetail(itemDto.getId(), values);
             }
+            //찾아온 ItemOptionDetailQuantity의 id를 가지고 redis에서 재고를 조회
+            int nowStock = redisService.getValuesItemCount(id);
+            if (nowStock - itemDto.getCount() < 0) {
+                throw new OrTopiaException(ErrorCode.ITEM_QUANTITY_ERROR);
+            }
+            // redis내 재고를 업데이트
+            redisService.setItemQuantity(id, nowStock - itemDto.getCount());
         }
         /** 요청 헤더 */
         String auth = "KakaoAK " + adminKey;


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)

- [x] 기능 추가
- [x] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 

- 아이템의 옵션을 추가!
 각 아이템은 사용자가 만든 커스텀 옵션을 가질 수 있습니다.

<br />

## :: 구현 사항 설명 

### :: 아이템의 생성
1. 아이템 옵션 데이터의 입력

- 현재 postman을 통해서 입력이 가능합니다.
예시 )
optionList = [
    {"optionName": "사이즈", "details": ["XL","L","M"]},
    {"optionName": "색상", "details": ["red", "black","blue"]}
]
- optionName은 최대 3개까지 가능합니다.

2. 받아온 optionList 를 재귀함수를 통해 모든 경우의 수를 생성하여 DB에 저장합니다. 

- 처음 입력한 item의 재고가 모든 경우의 수의 quantity에 들어갑니다. (추후..수정 안할래)
- 옵션이 없는 경우에는 "NONE" 이라는 문자열이 들어갑니다.(이는 DB 조회 시 디폴트 값을 NONE으로 하기 위함입니다)

3. 각 옵션의 경우의 수마다 재고를 가져야 함으로 Redis에 각 옵션의 ID 로 재고를 저장합니다. 

### :: 주문의 검증

1. 주문이 들어올 시  신규 List<ItemDto>List안 ItemDto안에 신규 List<ItemOptionDto> options를 하나 더 받아옵니다.
- options의 각 데이터는 {["사이즈" : 240],["색상":"red"]} 이런식의 사용자가 선택한 option에 대한 정보가 담겨있습니다. 

2. options의 데이터를 이용하여 ItemServer로 FeignClient요청을 보내서 재고를 저장하는 key를 받아 옵니다.
- itemId, 240, red 와 같이 item의 id와 선택한  옵션의 value가 보내집니다.
- 이를 통해 쿼리문을 통해 주어진 조건에 맞는 조합의 id를 찾아 옵니다. 

3. 추후 재고 검증 로직은 같습니다..

### :: 미 개발
1. order에 옵션에 대한 정보를 넣어주기

<br />

## :: Issue 포인트

- 옵션의 값들은 사이즈 제한은 아직 정해지지 않았지만 n * n * n 개의 조합이 생김으로 추후 제한이  필요합니다.

- 프론트에서 아이템을 만드는 화면에 대해 개발이 필요합니다. 

- 재귀함수를 사용하는 것이 맞나 싶습니다.

- 주문이 들어올 시  신규 List<ItemDto>List안 ItemDto안에 신규 List<ItemOptionDto> options를 하나 더 받아옵니다. 에서 feign을 여러번 보내는게 마음에 걸립니다

<br />

## :: 기타 질문 및 특이 사항

- 우..옵션
