### PR TITLE
feat : 리뷰 관련 API 구현 및 주문내역에 옵션 값 추가.

### DIFF
--- a/gateway/src/main/java/com/example/ordering_lecture/securities/JwtGlobalFilter.java
+++ b/gateway/src/main/java/com/example/ordering_lecture/securities/JwtGlobalFilter.java
@@ -33,7 +33,7 @@ public class JwtGlobalFilter implements GlobalFilter {
     @Autowired
     private RedisTemplate<String, String> redisTemplate; // Changed to String, String
 
-    private final List<String> allowUrl = Arrays.asList("/member/create", "/doLogin", "/item/items","/item/read/{id}","/payment/success/{email}", "/notices", "/notice/{id}","/payment/cancel","/payment/fail");
+    private final List<String> allowUrl = Arrays.asList("/member/create", "/doLogin", "/item/items","/item/read/{id}","/payment/success/{email}", "/notices", "/notice/{id}","/payment/cancel","/payment/fail","/review/show_item/{itemId}");
     private final AntPathMatcher antPathMatcher = new AntPathMatcher();
 
     @Override

--- a/item/src/main/java/com/example/ordering_lecture/item/controller/ItemController.java
+++ b/item/src/main/java/com/example/ordering_lecture/item/controller/ItemController.java
@@ -93,14 +93,14 @@ public class ItemController {
     }
 
     @GetMapping("read/{id}/my_page")
-    public ResponseEntity<OrTopiaResponse> readItemForMyPage(@PathVariable Long id,@RequestHeader("myEmail") String email){
+    public ResponseEntity<OrTopiaResponse> readItemForMyPage(@PathVariable Long id,@RequestHeader("myEmail") String email) {
         ItemResponseDto itemResponseDto = itemService.readItemForMyPage(id, email);
-        OrTopiaResponse orTopiaResponse = new OrTopiaResponse("read success",itemResponseDto);
-        return new ResponseEntity<>(orTopiaResponse,HttpStatus.OK);
-
+        OrTopiaResponse orTopiaResponse = new OrTopiaResponse("read success", itemResponseDto);
+        return new ResponseEntity<>(orTopiaResponse, HttpStatus.OK);
+    }
     // 조건에 맞는 item의 itemOptionQuantityId를 찾아오는 api
     @PostMapping("/search/optionDetailId/{itemId}")
-    Long searchIdByOptionDetail(@PathVariable Long itemId,@RequestBody List<String> values){
+    public Long searchIdByOptionDetail(@PathVariable Long itemId,@RequestBody List<String> values){
        return itemService.searchIdByOptionDetail(itemId,values);
     }
 }

--- a/item/src/main/java/com/example/ordering_lecture/item/controller/MemberServiceClient.java
+++ b/item/src/main/java/com/example/ordering_lecture/item/controller/MemberServiceClient.java
@@ -10,4 +10,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 public interface MemberServiceClient {
     @GetMapping("/member/search/{email}")
     Long searchIdByEmail(@PathVariable("email") String email);
+
+    @GetMapping("/member/search/name/{email}")
+    String searchNameByEmail(@PathVariable("email") String email);
 }

--- a/item/src/main/java/com/example/ordering_lecture/item/dto/ItemRequestDto.java
+++ b/item/src/main/java/com/example/ordering_lecture/item/dto/ItemRequestDto.java
@@ -38,6 +38,8 @@ public class ItemRequestDto {
             Category category = null;
             category = Category.valueOf(this.getCategory());
             return Item.builder()
+                    .reviewNumber(0L)
+                    .score(0L)
                     .name(this.getName())
                     .price(this.getPrice())
                     .category(category)

--- a/item/src/main/java/com/example/ordering_lecture/item/dto/ItemResponseDto.java
+++ b/item/src/main/java/com/example/ordering_lecture/item/dto/ItemResponseDto.java
@@ -30,10 +30,14 @@ public class ItemResponseDto {
     private Long sellerId;
     private List<ItemOptionResponseDto> itemOptionResponseDtoList;
     private String createdTime;
+    private Long reviewNumber;
+    private Long score;
 
 
     public static ItemResponseDto toDto(Item item){
         return ItemResponseDto.builder()
+                .reviewNumber(item.getReviewNumber())
+                .score(item.getScore())
                 .name(item.getName())
                 .imagePath(item.getImagePath())
                 .price(item.getPrice())

--- a/item/src/main/java/com/example/ordering_lecture/item/entity/Item.java
+++ b/item/src/main/java/com/example/ordering_lecture/item/entity/Item.java
@@ -45,6 +45,10 @@ public class Item {
     private Long sellerId;
     @OneToMany(mappedBy = "item",fetch = FetchType.LAZY, orphanRemoval = true,cascade = CascadeType.ALL)
     private List<Review> review;
+    @Column
+    private Long reviewNumber;
+    @Column
+    private Long score;
     @CreationTimestamp
     private LocalDateTime createdTime;
 
@@ -80,5 +84,10 @@ public class Item {
     }
     public void deleteItem(){
         this.delYN = true;
+    }
+
+    public void updateScore(byte score) {
+        this.reviewNumber++;
+        this.score += score;
     }
 }

--- a/item/src/main/java/com/example/ordering_lecture/item/service/ItemService.java
+++ b/item/src/main/java/com/example/ordering_lecture/item/service/ItemService.java
@@ -264,9 +264,10 @@ public class ItemService {
     }
 
     public ItemResponseDto readItemForMyPage(Long itemId, String email) {
-        Item item = itemRepository.findImagePathById(itemId).orElseThrow(()->new OrTopiaException(ErrorCode.NOT_FOUND_ITEM));
+        Item item = itemRepository.findImagePathById(itemId).orElseThrow(() -> new OrTopiaException(ErrorCode.NOT_FOUND_ITEM));
         ItemResponseDto itemResponseDto = ItemResponseDto.toDto(item);
         return itemResponseDto;
+    }
 
     public Long searchIdByOptionDetail(Long itemId, List<String> values) {
         String value1 = "NONE";

--- a/item/src/main/java/com/example/ordering_lecture/item/service/ItemService.java
+++ b/item/src/main/java/com/example/ordering_lecture/item/service/ItemService.java
@@ -120,6 +120,7 @@ public class ItemService {
     }
 
     public List<ItemResponseDto> showAllItem(){
+
         return itemRepository.findAll().stream()
                 .map(ItemResponseDto::toDto)
                 .collect(Collectors.toList());

--- a/item/src/main/java/com/example/ordering_lecture/redis/RedisService.java
+++ b/item/src/main/java/com/example/ordering_lecture/redis/RedisService.java
@@ -35,7 +35,7 @@ public class RedisService {
     @Transactional(readOnly = true)
     public Set<String> getValues(String key) {
         ZSetOperations<String, String> values = redisTemplate.opsForZSet();
-        return values.range(key,0,2);
+        return values.range(key,0,4);
     }
 
     @Transactional(readOnly = true)

--- a/item/src/main/java/com/example/ordering_lecture/review/controller/OrderServiceClient.java
+++ b/item/src/main/java/com/example/ordering_lecture/review/controller/OrderServiceClient.java
@@ -1,0 +1,13 @@
+package com.example.ordering_lecture.review.controller;
+
+import com.example.ordering_lecture.common.OrTopiaResponse;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@FeignClient(name = "order-service")
+public interface OrderServiceClient {
+    @GetMapping("check/review/{orderDetailId}")
+    OrTopiaResponse checkReview(@PathVariable(name = "orderDetailId") Long orderDetailId);
+
+}

--- a/item/src/main/java/com/example/ordering_lecture/review/controller/ReviewController.java
+++ b/item/src/main/java/com/example/ordering_lecture/review/controller/ReviewController.java
@@ -22,7 +22,7 @@ public class ReviewController {
     }
 
     @PostMapping("/create")
-    public ResponseEntity<OrTopiaResponse> createReview(@Valid @RequestBody ReviewRequestDto reviewRequestDto){
+    public ResponseEntity<OrTopiaResponse> createReview(@Valid @ModelAttribute ReviewRequestDto reviewRequestDto){
         ReviewResponseDto reviewResponseDto = reviewService.createReview(reviewRequestDto);
         OrTopiaResponse orTopiaResponse = new OrTopiaResponse("create success",reviewResponseDto);
         return new ResponseEntity<>(orTopiaResponse, HttpStatus.CREATED);
@@ -42,9 +42,9 @@ public class ReviewController {
         return new ResponseEntity<>(orTopiaResponse, HttpStatus.OK);
     }
     // 특정 사용자가 작성한 리뷰 조회
-    @GetMapping("/show_buyer/{buyerId}")
-    public ResponseEntity<OrTopiaResponse> showBuyerReviews(@PathVariable Long buyerId){
-        List<ReviewResponseDto> reviewResponseDtoList = reviewService.showBuyerReviews(buyerId);
+    @GetMapping("/show_buyer/{email}")
+    public ResponseEntity<OrTopiaResponse> showBuyerReviews(@PathVariable String email){
+        List<ReviewResponseDto> reviewResponseDtoList = reviewService.showBuyerReviews(email);
         OrTopiaResponse orTopiaResponse = new OrTopiaResponse("read success",reviewResponseDtoList);
         return new ResponseEntity<>(orTopiaResponse, HttpStatus.OK);
     }

--- a/item/src/main/java/com/example/ordering_lecture/review/dto/ReviewRequestDto.java
+++ b/item/src/main/java/com/example/ordering_lecture/review/dto/ReviewRequestDto.java
@@ -5,6 +5,7 @@ import com.example.ordering_lecture.review.entity.Review;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.springframework.web.multipart.MultipartFile;
 
 import javax.validation.constraints.NotNull;
 
@@ -17,16 +18,21 @@ public class ReviewRequestDto {
     @NotNull(message = "EMPTY_REVIEW_CONTENT")
     private String content;
     @NotNull(message = "EMPTY_REVIEW_BUYER_ID")
-    private Long buyerId;
+    private String buyerEmail;
     @NotNull(message = "EMPTY_REVIEW_ITEM_ID")
     private Long itemId;
+    @NotNull()
+    private Long orderDetailId;
+    private MultipartFile imagePath;
 
-    public Review toEntity(Item item){
+    public Review toEntity(Item item,String imagePath){
         return Review.builder()
                 .score(this.score)
                 .content(this.content)
-                .buyerId(this.buyerId)
+                .orderDetailId(orderDetailId)
+                .buyerEmail(this.buyerEmail)
                 .item(item)
+                .imagePath(imagePath)
                 .build();
     }
 }

--- a/item/src/main/java/com/example/ordering_lecture/review/dto/ReviewResponseDto.java
+++ b/item/src/main/java/com/example/ordering_lecture/review/dto/ReviewResponseDto.java
@@ -6,6 +6,8 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.time.format.DateTimeFormatter;
+
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
@@ -14,16 +16,24 @@ public class ReviewResponseDto {
     private Long id;
     private byte score;
     private String content;
-    private Long buyerId;
+    private String buyerEmail;
+    private String name;
     private Long itemId;
+    private String imagePath;
+    private String date;
 
-    public static ReviewResponseDto toDto(Review review){
+    public static ReviewResponseDto toDto(Review review,String name){
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+        String formattedDateTime = review.getCreatedTime().format(formatter);
         return ReviewResponseDto.builder()
-                .buyerId(review.getBuyerId())
+                .name(name)
+                .date(formattedDateTime)
+                .buyerEmail(review.getBuyerEmail())
                 .id(review.getId())
                 .itemId(review.getItem().getId())
                 .score(review.getScore())
                 .content(review.getContent())
+                .imagePath(review.getImagePath())
                 .build();
     }
 }

--- a/item/src/main/java/com/example/ordering_lecture/review/entity/Review.java
+++ b/item/src/main/java/com/example/ordering_lecture/review/entity/Review.java
@@ -22,9 +22,13 @@ public class Review {
     @Column(nullable = false)
     private byte score;
     @Column(nullable = false)
+    private Long orderDetailId;
+    @Column(nullable = false)
     private String content;
     @Column(nullable = false)
-    private Long buyerId;
+    private String buyerEmail;
+    @Column
+    private String imagePath;
     @JoinColumn(name="item_id",nullable = false)
     @ManyToOne(fetch = FetchType.LAZY)
     private Item item;

--- a/item/src/main/java/com/example/ordering_lecture/review/repository/ReviewRepository.java
+++ b/item/src/main/java/com/example/ordering_lecture/review/repository/ReviewRepository.java
@@ -11,5 +11,5 @@ public interface ReviewRepository  extends JpaRepository<Review,Long> {
 
     List<Review> findAllByItemId(Long itemId);
 
-    List<Review> findAllByBuyerId(Long buyerId);
+    List<Review> findAllByBuyerEmail(String buyerEmail);
 }

--- a/item/src/main/java/com/example/ordering_lecture/review/service/ReviewService.java
+++ b/item/src/main/java/com/example/ordering_lecture/review/service/ReviewService.java
@@ -1,18 +1,25 @@
 package com.example.ordering_lecture.review.service;
 
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.DeleteObjectRequest;
+import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.example.ordering_lecture.common.ErrorCode;
 import com.example.ordering_lecture.common.OrTopiaException;
+import com.example.ordering_lecture.item.controller.MemberServiceClient;
 import com.example.ordering_lecture.item.entity.Item;
 import com.example.ordering_lecture.item.repository.ItemRepository;
+import com.example.ordering_lecture.review.controller.OrderServiceClient;
 import com.example.ordering_lecture.review.dto.ReviewRequestDto;
 import com.example.ordering_lecture.review.dto.ReviewResponseDto;
 import com.example.ordering_lecture.review.dto.ReviewUpdateDto;
 import com.example.ordering_lecture.review.entity.Review;
 import com.example.ordering_lecture.review.repository.ReviewRepository;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.stereotype.Service;
 
 import javax.transaction.Transactional;
+import java.io.IOException;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -20,19 +27,44 @@ import java.util.stream.Collectors;
 public class ReviewService {
     private final ReviewRepository reviewRepository;
     private final ItemRepository itemRepository;
+    private final AmazonS3Client amazonS3Client;
+    private final OrderServiceClient orderServiceClient;
+    private final MemberServiceClient memberServiceClient;
 
-    public ReviewService(ReviewRepository reviewRepository, ItemRepository itemRepository) {
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    public ReviewService(ReviewRepository reviewRepository, ItemRepository itemRepository, AmazonS3Client amazonS3Client, OrderServiceClient orderServiceClient, MemberServiceClient memberServiceClient) {
         this.reviewRepository = reviewRepository;
         this.itemRepository = itemRepository;
+        this.amazonS3Client = amazonS3Client;
+        this.orderServiceClient = orderServiceClient;
+        this.memberServiceClient = memberServiceClient;
     }
 
+    @Transactional
     public ReviewResponseDto createReview(ReviewRequestDto reviewRequestDto)throws OrTopiaException {
         Item item = itemRepository.findById(reviewRequestDto.getItemId()).orElseThrow(
                 ()-> new OrTopiaException(ErrorCode.NOT_FOUND_ITEM)
         );
-        Review review = reviewRequestDto.toEntity(item);
+        String fileName = reviewRequestDto.getBuyerEmail() + System.currentTimeMillis();
+        String fileUrl = null;
+        try{
+            ObjectMetadata metadata = new ObjectMetadata();
+            metadata.setContentType(reviewRequestDto.getImagePath().getContentType());
+            metadata.setContentLength(reviewRequestDto.getImagePath().getSize());
+            amazonS3Client.putObject(bucket, fileName, reviewRequestDto.getImagePath().getInputStream(), metadata);
+            fileUrl = amazonS3Client.getUrl(bucket, fileName).toString();
+        } catch (IOException e) {
+            throw new OrTopiaException(ErrorCode.S3_SERVER_ERROR);
+        }
+        Review review = reviewRequestDto.toEntity(item,fileUrl);
         reviewRepository.save(review);
-        return ReviewResponseDto.toDto(review);
+        // 리뷰 작성시 Item 리뷰 수 , 총점수 업데이트.
+        item.updateScore(reviewRequestDto.getScore());
+        //TODO : 추후 카프카로 변경. 주문디테일 테이블에 리뷰 작성 표시.
+        orderServiceClient.checkReview(reviewRequestDto.getOrderDetailId());
+        return ReviewResponseDto.toDto(review,null);
     }
 
     public List<ReviewResponseDto> showAllReview()throws OrTopiaException{
@@ -41,7 +73,10 @@ public class ReviewService {
             throw new OrTopiaException(ErrorCode.EMPTY_REVIEWS);
         }
         return reviews.stream()
-                .map(ReviewResponseDto::toDto)
+                .map(review -> {
+                    String name = memberServiceClient.searchNameByEmail(review.getBuyerEmail());
+                    return ReviewResponseDto.toDto(review,name);
+                })
                 .collect(Collectors.toList());
     }
 
@@ -51,16 +86,22 @@ public class ReviewService {
             throw new OrTopiaException(ErrorCode.EMPTY_REVIEWS);
         }
         return reviews.stream()
-                .map(ReviewResponseDto::toDto)
+                .map(review -> {
+                  String name = memberServiceClient.searchNameByEmail(review.getBuyerEmail());
+                  return ReviewResponseDto.toDto(review,name);
+                })
                 .collect(Collectors.toList());
     }
-    public List<ReviewResponseDto> showBuyerReviews(Long buyerId)throws OrTopiaException {
-        List<Review> reviews = reviewRepository.findAllByBuyerId(buyerId);
+    public List<ReviewResponseDto> showBuyerReviews(String email)throws OrTopiaException {
+        List<Review> reviews = reviewRepository.findAllByBuyerEmail(email);
         if(reviews.isEmpty()){
             throw new OrTopiaException(ErrorCode.EMPTY_REVIEWS);
         }
         return reviews.stream()
-                .map(ReviewResponseDto::toDto)
+                .map(review -> {
+                    String name = memberServiceClient.searchNameByEmail(review.getBuyerEmail());
+                    return ReviewResponseDto.toDto(review,name);
+                })
                 .collect(Collectors.toList());
     }
     public void deleteReview(Long id) throws OrTopiaException{
@@ -75,6 +116,7 @@ public class ReviewService {
     public ReviewResponseDto updateReview(ReviewUpdateDto reviewUpdateDto)throws OrTopiaException {
         Review review = reviewRepository.findById(reviewUpdateDto.getId()).orElseThrow();
         reviewUpdateDto.toUpdate(review);
-        return ReviewResponseDto.toDto(review);
+        String name = memberServiceClient.searchNameByEmail(review.getBuyerEmail());
+        return ReviewResponseDto.toDto(review,name);
     }
 }

--- a/member/src/main/java/com/example/ordering_lecture/member/controller/MemberController.java
+++ b/member/src/main/java/com/example/ordering_lecture/member/controller/MemberController.java
@@ -119,11 +119,17 @@ public class MemberController {
         memberService.unlikeSeller(buyerEmail, sellerId);
         OrTopiaResponse orTopiaResponse = new OrTopiaResponse("delete success", null);
         return new ResponseEntity<>(orTopiaResponse, HttpStatus.OK);
+    }
     // 판매 내역 조회 시 사용되는 API
     // front로 넘어오는 email 값을 이용해 seller ID를 조회
     @GetMapping("/member/{email}/memberId")
     public Long findIdByMemberEmail(@PathVariable("email") String email){
         MemberResponseDto memberResponseDto = memberService.findIdByEmail(email);
         return memberResponseDto.getId();
+    }
+    // 이메일을 통해서 이름을 찾는 API
+    @GetMapping("/member/search/name/{email}")
+    public String searchNameByEmail(@PathVariable("email") String email){
+        return memberService.searchNameByEmail(email);
     }
 }

--- a/member/src/main/java/com/example/ordering_lecture/member/service/MemberService.java
+++ b/member/src/main/java/com/example/ordering_lecture/member/service/MemberService.java
@@ -180,4 +180,11 @@ public class MemberService {
                 .orElseThrow(() -> new IllegalArgumentException("이메일을 찾지 못했습니다. " + email));
         return MemberResponseDto.toDto(member);
     }
+
+    public String searchNameByEmail(String email) {
+        Member member = memberRepository.findByEmail(email).orElseThrow(
+                ()-> new OrTopiaException(ErrorCode.NOT_FOUND_MEMBER)
+                );
+        return member.getName();
+    }
 }

--- a/order/src/main/java/com/example/ordering_lecture/common/ErrorCode.java
+++ b/order/src/main/java/com/example/ordering_lecture/common/ErrorCode.java
@@ -8,7 +8,8 @@ import javax.validation.constraints.NotNull;
 public enum ErrorCode {
     REDIS_ERROR("O1","redis 저장에 실패했습니다."),
     ACCESS_DENIED("O2","잘못된 접근입니다."),
-    ITEM_QUANTITY_ERROR("O3","아이템의 재고가 부족합니다." );
+    ITEM_QUANTITY_ERROR("O3","아이템의 재고가 부족합니다." ),
+    NOT_FOUND_ORDERDETAIL("O4","해당 상세 주문이 없습니다.");
     private final String code;
     private final String message;
 

--- a/order/src/main/java/com/example/ordering_lecture/order/service/OrderingService.java
+++ b/order/src/main/java/com/example/ordering_lecture/order/service/OrderingService.java
@@ -9,6 +9,7 @@ import com.example.ordering_lecture.orderdetail.dto.OrderDetailRequestDto;
 import com.example.ordering_lecture.orderdetail.dto.OrderDetailResponseDto;
 import com.example.ordering_lecture.orderdetail.entity.OrderDetail;
 import com.example.ordering_lecture.orderdetail.repository.OrderDetailRepository;
+import com.example.ordering_lecture.payment.dto.ItemOptionDto;
 import com.example.ordering_lecture.redis.RedisService;
 import org.springframework.stereotype.Service;
 
@@ -37,8 +38,14 @@ public class OrderingService {
             Ordering ordering = orderRequestDto.toEntity();
             orderRepository.save(ordering);
             for(OrderDetailRequestDto orderDetailRequestDto:orderRequestDto.getOrderDetailRequestDtoList()){
-                OrderDetail orderDetail = orderDetailRequestDto.toEntity(ordering);
-                System.out.println(orderDetailRequestDto.getSellerId());
+                StringBuilder sb = new StringBuilder();
+                for(ItemOptionDto itemOptionDto :orderDetailRequestDto.getOptions()){
+                    String optionName =  itemOptionDto.getName();
+                    String optionValue = itemOptionDto.getValue();
+                    sb.append(optionName);
+                    sb.append(" : "+optionValue+" ");
+                }
+                OrderDetail orderDetail = orderDetailRequestDto.toEntity(ordering,sb.toString());
                 orderDetailRepository.save(orderDetail);
             }
             return OrderResponseDto.toDto(ordering);

--- a/order/src/main/java/com/example/ordering_lecture/orderdetail/OrderDetailController.java
+++ b/order/src/main/java/com/example/ordering_lecture/orderdetail/OrderDetailController.java
@@ -1,0 +1,25 @@
+package com.example.ordering_lecture.orderdetail;
+
+import com.example.ordering_lecture.common.OrTopiaResponse;
+import com.example.ordering_lecture.orderdetail.service.OrderDetailService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class OrderDetailController {
+    private final OrderDetailService orderDetailService;
+
+    public OrderDetailController(OrderDetailService orderDetailService) {
+        this.orderDetailService = orderDetailService;
+    }
+
+    @GetMapping("check/review/{orderDetailId}")
+    public ResponseEntity<OrTopiaResponse> checkReview(@PathVariable Long orderDetailId){
+        orderDetailService.updateReview(orderDetailId);
+        OrTopiaResponse orTopiaResponse = new OrTopiaResponse("update success");
+        return new ResponseEntity<>(orTopiaResponse, HttpStatus.OK);
+    }
+}

--- a/order/src/main/java/com/example/ordering_lecture/orderdetail/dto/OrderDetailRequestDto.java
+++ b/order/src/main/java/com/example/ordering_lecture/orderdetail/dto/OrderDetailRequestDto.java
@@ -2,9 +2,12 @@ package com.example.ordering_lecture.orderdetail.dto;
 
 import com.example.ordering_lecture.order.entity.Ordering;
 import com.example.ordering_lecture.orderdetail.entity.OrderDetail;
+import com.example.ordering_lecture.payment.dto.ItemOptionDto;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+
+import java.util.List;
 
 @Data
 @AllArgsConstructor
@@ -14,9 +17,11 @@ public class OrderDetailRequestDto {
     private Long id;
     private int count;
     private Long sellerId;
-    public OrderDetail toEntity(Ordering ordering){
+    private List<ItemOptionDto> options;
+    public OrderDetail toEntity(Ordering ordering,String options){
         return OrderDetail.builder()
                 .ordering(ordering)
+                .options(options)
                 .itemId(this.id)
                 .sellerId(this.sellerId)
                 .quantity(this.count)

--- a/order/src/main/java/com/example/ordering_lecture/orderdetail/dto/OrderDetailResponseDto.java
+++ b/order/src/main/java/com/example/ordering_lecture/orderdetail/dto/OrderDetailResponseDto.java
@@ -19,10 +19,16 @@ public class OrderDetailResponseDto {
     private int quantity;
     private Long sellerId;
     private int discountPrice;
+    private String options;
+    private boolean isReviewed;
+    private Long id;
 
     public static OrderDetailResponseDto toDto(OrderDetail orderDetail){
         return OrderDetailResponseDto.builder()
+                .id(orderDetail.getId())
+                .isReviewed(orderDetail.isReviewed())
                 .orderingId(orderDetail.getOrdering().getId())
+                .options(orderDetail.getOptions())
                 .itemId(orderDetail.getItemId())
                 .quantity(orderDetail.getQuantity())
                 .sellerId(orderDetail.getSellerId())

--- a/order/src/main/java/com/example/ordering_lecture/orderdetail/entity/OrderDetail.java
+++ b/order/src/main/java/com/example/ordering_lecture/orderdetail/entity/OrderDetail.java
@@ -29,9 +29,15 @@ public class OrderDetail {
     @Column(nullable = false)
     private int quantity;
     private int discountPrice;
+    @Column
+    private String options;
     @Column(nullable = false)
     @Builder.Default
     private boolean isReviewed = false;
     @CreationTimestamp
     private LocalDateTime createdTime;
+
+    public void updateReview() {
+        isReviewed = true;
+    }
 }

--- a/order/src/main/java/com/example/ordering_lecture/orderdetail/service/OrderDetailService.java
+++ b/order/src/main/java/com/example/ordering_lecture/orderdetail/service/OrderDetailService.java
@@ -1,0 +1,25 @@
+package com.example.ordering_lecture.orderdetail.service;
+
+import com.example.ordering_lecture.common.ErrorCode;
+import com.example.ordering_lecture.common.OrTopiaException;
+import com.example.ordering_lecture.orderdetail.entity.OrderDetail;
+import com.example.ordering_lecture.orderdetail.repository.OrderDetailRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class OrderDetailService {
+    private final OrderDetailRepository orderDetailRepository;
+
+    public OrderDetailService(OrderDetailRepository orderDetailRepository) {
+        this.orderDetailRepository = orderDetailRepository;
+    }
+    @Transactional
+    public void updateReview(Long orderDetailId){
+        OrderDetail orderDetail = orderDetailRepository.findById(orderDetailId).orElseThrow(
+                ()-> new OrTopiaException(ErrorCode.NOT_FOUND_ORDERDETAIL)
+        );
+        System.out.println(orderDetailId);
+        orderDetail.updateReview();
+    }
+}


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)

- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 

- 리뷰 관련 API 구현 

- 주문내역에 옵션 값 추가.

- 최근 본 상품 3개에서 5개를 보여주도록 구현.

<br />

## :: 구현 사항 설명 

1. 리뷰 관련 API 구현 

- 리뷰 엔티티의 컬럼을 변경 시켰습니다.
   buyerId -> buyerEmail
   imagePath 컬럼 추가 (리뷰 사진)
   orderDetailId 컬럼 추가 (특정 주문에 대한 리뷰인지 효율적으로 찾기 위해)

- 아이템 엔티티의 컬럼을 추가 했습니다.
  reviewNumber : 리뷰의 수
  score : 총점

- 리뷰가 생성되면서 아이템의 리뷰 관련 컬럼의 값을 update 시킵니다. 

- 리뷰가 생성되면서 feinclient를 통해 OrderDetail 테이블의 isReviewed 값을 update 시킵니다.

-  리뷰 응답 API 에서 feinclient를 통해 해당 멤버의 이름을 찾아옵니다.

2. 주문 내역에 option에 대한 컬럼 추가

- 주문 내역에 options 컬럼을 추가 했습니다
  사이즈 : 240  색깔 : red 이런 식으로 하나의 String 값이 저장됩니다. 

3. 최근 본 상품의 수를 3개에서 5개로 늘렸습니다. (화면이 허전해서 그랬습니다) 

<br />

## :: Issue 포인트 

- 추후 item의 isReviewd 컬럼 update를 카프카를 이용해야합니다.

