### PR TITLE
[feat] flushAll 메서드 삭제

### DIFF
--- a/item/src/main/java/com/example/ordering_lecture/redis/RedisService.java
+++ b/item/src/main/java/com/example/ordering_lecture/redis/RedisService.java
@@ -18,7 +18,7 @@ import java.util.Set;
 public class RedisService {
 
     private final StringRedisTemplate redisTemplate;
-    private final RedisTemplate redisTemplate2;
+    private final RedisTemplate<Long, String> redisTemplate2;
     private final RedisTemplate<Long, Object> redisTemplate3;
 
     public void setValues(String key, ItemResponseDto dto) {

--- a/recommendation/src/main/java/com/example/ordering_lecture/recommend/service/RecommendationService.java
+++ b/recommendation/src/main/java/com/example/ordering_lecture/recommend/service/RecommendationService.java
@@ -41,8 +41,8 @@ public class RecommendationService {
     }
 
     public void getRecommendations() {
-        // 기존 값들 비우기
-        redisService.flushAll();
+//        // 기존 값들 비우기
+//        redisService.flushAll();
 
         // jwt 토큰 발행 후 Redis 3번 채널에 저장
         jwtTokenProvider.createRecommandToken();
@@ -124,21 +124,5 @@ public class RecommendationService {
             redisService.setValues(id, recommendationRedisDatas);
             System.out.println(id + "번 사용자에게 아이템 추천 완료");
         }
-    }
-
-    public List<RecommendationRedisData> readRecommendationItems(Long id) {
-        List<String> list = redisService.getValues(id);
-        List<RecommendationRedisData> recommendationRedisDatas = new ArrayList<>();
-        ObjectMapper objectMapper = new ObjectMapper();
-        for(String str: list){
-            RecommendationRedisData  recommendationRedisData = null;
-            try {
-                recommendationRedisData = objectMapper.readValue(str, RecommendationRedisData.class);
-            } catch (JsonProcessingException e) {
-                throw new OrTopiaException(ErrorCode.JSON_PARSE_ERROR);
-            }
-            recommendationRedisDatas.add(recommendationRedisData);
-        }
-        return recommendationRedisDatas;
     }
 }

--- a/recommendation/src/main/java/com/example/ordering_lecture/redis/RedisService.java
+++ b/recommendation/src/main/java/com/example/ordering_lecture/redis/RedisService.java
@@ -36,7 +36,10 @@ public class RedisService {
         return values.range(key, 0, 2);
     }
 
-    public void flushAll(){
-        redisTemplate.getConnectionFactory().getConnection().serverCommands().flushAll();
-    }
+//    public void flushAll(){
+////        redisTemplate.getConnectionFactory().getConnection().serverCommands().flushAll();
+//        connectionFactory.setDatabase(2); // 2번 DB 선택
+//        redisTemplate.setConnectionFactory(connectionFactory);
+//        redisTemplate.getConnectionFactory().getConnection().serverCommands().flushDb(); // 2번 DB 삭제
+//    }
 }


### PR DESCRIPTION
## :: 최근 작업 주제
- [ ] 기능 추가
- [ ] 리뷰 반영
- [x] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 사항 설명
- flushAll을 수행하는 객체가 Redis 2번 DB에 연결되어 있지만, 어째서인지 모든 DB의 값을 지우는 문제 발생
- 이로 인해, RT 값까지 모두 지워 웹 서비스 이용 도중 AT 만료 시 AT 재발급 로직을 수행하지 않는 문제까지 발생
- 통합 테스트를 위해 일단 flushAll 함수 호출하는 부분을 주석 처리 했습니다

## :: 기타 질문 및 특이 사항
- 추후 로직 자체를 수정하거나, TTL을 24시간으로 설정하는 방식으로 변경하겠습니다