### PR TITLE
[feat] statue 컬럼 이동으로 인한 그래프 코드 수정

### DIFF
--- a/item/src/main/java/com/example/ordering_lecture/item/controller/ItemController.java
+++ b/item/src/main/java/com/example/ordering_lecture/item/controller/ItemController.java
@@ -130,7 +130,7 @@ public class ItemController {
         return new ResponseEntity<>(orTopiaResponse,HttpStatus.OK);
     }
     // 특정 아이템의 이름을 조회
-    @GetMapping("/{itemId}/itemName")
+    @PostMapping("/{itemId}/itemName")
     public String findNameById(@PathVariable Long itemId){
         return itemService.getItemName(itemId);
     }

--- a/order/src/main/java/com/example/ordering_lecture/order/OrderingController.java
+++ b/order/src/main/java/com/example/ordering_lecture/order/OrderingController.java
@@ -5,8 +5,11 @@ import com.example.ordering_lecture.common.OrTopiaException;
 import com.example.ordering_lecture.common.OrTopiaResponse;
 import com.example.ordering_lecture.order.dto.*;
 import com.example.ordering_lecture.order.service.OrderingService;
+import com.example.ordering_lecture.orderdetail.controller.MemberServiceClient;
 import com.example.ordering_lecture.orderdetail.dto.BuyerGraphCountData;
 import com.example.ordering_lecture.orderdetail.dto.BuyerGraphPriceData;
+import com.example.ordering_lecture.orderdetail.dto.SellerGraphCountData;
+import com.example.ordering_lecture.orderdetail.dto.SellerGraphPriceData;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -16,8 +19,10 @@ import java.util.List;
 @RestController
 public class OrderingController {
     private final OrderingService orderingService;
-    public OrderingController(OrderingService orderingService) {
+    private final MemberServiceClient memberServiceClient;
+    public OrderingController(OrderingService orderingService, MemberServiceClient memberServiceClient) {
         this.orderingService = orderingService;
+        this.memberServiceClient = memberServiceClient;
     }
 
     //주문 생성
@@ -78,18 +83,18 @@ public class OrderingController {
         OrTopiaResponse orTopiaResponse = new OrTopiaResponse("read success",buyerGraphCountDatas);
         return new ResponseEntity<>(orTopiaResponse,HttpStatus.OK);
     }
-//    @GetMapping("/total_price/seller")
-//    public ResponseEntity<OrTopiaResponse> totalPriceBySeller(@RequestHeader("myEmail") String email){
-//        Long sellerId = feignClient.findIdByMemberEmail(email);
-//        List<SellerGraphPriceData> sellerGraphPriceDatas = orderingService.getSellerGraphPriceData(sellerId);
-//        OrTopiaResponse orTopiaResponse = new OrTopiaResponse("read success",sellerGraphPriceDatas);
-//        return new ResponseEntity<>(orTopiaResponse,HttpStatus.OK);
-//    }
-//    @GetMapping("/total_count/seller")
-//    public ResponseEntity<OrTopiaResponse> totalCountBySeller(@RequestHeader("myEmail") String email){
-//        Long sellerId = feignClient.findIdByMemberEmail(email);
-//        List<SellerGraphCountData> sellerGraphCountDatas = orderingService.getSellerGraphCountData(sellerId);
-//        OrTopiaResponse orTopiaResponse = new OrTopiaResponse("read success",sellerGraphCountDatas);
-//        return new ResponseEntity<>(orTopiaResponse,HttpStatus.OK);
-//    }
+    @GetMapping("/total_price/seller")
+    public ResponseEntity<OrTopiaResponse> totalPriceBySeller(@RequestHeader("myEmail") String email){
+        Long sellerId = memberServiceClient.searchIdByEmail(email);
+        List<SellerGraphPriceData> sellerGraphPriceDatas = orderingService.getSellerGraphPriceData(sellerId);
+        OrTopiaResponse orTopiaResponse = new OrTopiaResponse("read success",sellerGraphPriceDatas);
+        return new ResponseEntity<>(orTopiaResponse,HttpStatus.OK);
+    }
+    @GetMapping("/total_count/seller")
+    public ResponseEntity<OrTopiaResponse> totalCountBySeller(@RequestHeader("myEmail") String email){
+        Long sellerId = memberServiceClient.searchIdByEmail(email);
+        List<SellerGraphCountData> sellerGraphCountDatas = orderingService.getSellerGraphCountData(sellerId);
+        OrTopiaResponse orTopiaResponse = new OrTopiaResponse("read success",sellerGraphCountDatas);
+        return new ResponseEntity<>(orTopiaResponse,HttpStatus.OK);
+    }
 }

--- a/order/src/main/java/com/example/ordering_lecture/order/OrderingController.java
+++ b/order/src/main/java/com/example/ordering_lecture/order/OrderingController.java
@@ -5,6 +5,8 @@ import com.example.ordering_lecture.common.OrTopiaException;
 import com.example.ordering_lecture.common.OrTopiaResponse;
 import com.example.ordering_lecture.order.dto.*;
 import com.example.ordering_lecture.order.service.OrderingService;
+import com.example.ordering_lecture.orderdetail.dto.BuyerGraphCountData;
+import com.example.ordering_lecture.orderdetail.dto.BuyerGraphPriceData;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -64,18 +66,18 @@ public class OrderingController {
         OrTopiaResponse orTopiaResponse = new OrTopiaResponse("read success",orderResponseForSellerDtos);
         return new ResponseEntity<>(orTopiaResponse,HttpStatus.OK);
     }
-//    @GetMapping("/total_price")
-//    public ResponseEntity<OrTopiaResponse> totalPrice(@RequestHeader("myEmail") String email){
-//        List<BuyerGraphPriceData> buyerGraphPriceDatas = orderingService.getBuyerGraphPriceData(email);
-//        OrTopiaResponse orTopiaResponse = new OrTopiaResponse("read success",buyerGraphPriceDatas);
-//        return new ResponseEntity<>(orTopiaResponse,HttpStatus.OK);
-//    }
-//    @GetMapping("/total_count")
-//    public ResponseEntity<OrTopiaResponse> totalCount(@RequestHeader("myEmail") String email){
-//        List<BuyerGraphCountData> buyerGraphCountDatas = orderingService.getBuyerGraphCountData(email);
-//        OrTopiaResponse orTopiaResponse = new OrTopiaResponse("read success",buyerGraphCountDatas);
-//        return new ResponseEntity<>(orTopiaResponse,HttpStatus.OK);
-//    }
+    @GetMapping("/total_price")
+    public ResponseEntity<OrTopiaResponse> totalPrice(@RequestHeader("myEmail") String email){
+        List<BuyerGraphPriceData> buyerGraphPriceDatas = orderingService.getBuyerGraphPriceData(email);
+        OrTopiaResponse orTopiaResponse = new OrTopiaResponse("read success",buyerGraphPriceDatas);
+        return new ResponseEntity<>(orTopiaResponse,HttpStatus.OK);
+    }
+    @GetMapping("/total_count")
+    public ResponseEntity<OrTopiaResponse> totalCount(@RequestHeader("myEmail") String email){
+        List<BuyerGraphCountData> buyerGraphCountDatas = orderingService.getBuyerGraphCountData(email);
+        OrTopiaResponse orTopiaResponse = new OrTopiaResponse("read success",buyerGraphCountDatas);
+        return new ResponseEntity<>(orTopiaResponse,HttpStatus.OK);
+    }
 //    @GetMapping("/total_price/seller")
 //    public ResponseEntity<OrTopiaResponse> totalPriceBySeller(@RequestHeader("myEmail") String email){
 //        Long sellerId = feignClient.findIdByMemberEmail(email);

--- a/order/src/main/java/com/example/ordering_lecture/order/repository/OrderRepository.java
+++ b/order/src/main/java/com/example/ordering_lecture/order/repository/OrderRepository.java
@@ -1,7 +1,5 @@
 package com.example.ordering_lecture.order.repository;
 
-import com.example.ordering_lecture.order.dto.BuyerGraphCountData;
-import com.example.ordering_lecture.order.dto.BuyerGraphPriceData;
 import com.example.ordering_lecture.order.entity.Ordering;
 import com.example.ordering_lecture.orderdetail.entity.OrderDetail;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -9,7 +7,6 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
-import java.time.LocalDateTime;
 import java.util.List;
 
 @Repository
@@ -17,10 +14,4 @@ public interface OrderRepository extends JpaRepository<Ordering,Long> {
     List<Ordering> findAllByEmail(String email);
     @Query("SELECT od FROM OrderDetail od  JOIN od.ordering o WHERE od.sellerId = :sellerId")
     List<OrderDetail> findAllBySeller(@Param("sellerId") Long sellerId);
-
-//    @Query("SELECT new com.example.ordering_lecture.order.dto.BuyerGraphPriceData(DATE(o.createdTime) as createdTime, SUM(o.totalPrice) as price) FROM Ordering o WHERE o.createdTime BETWEEN :startDate AND :endDate AND o.statue = 'COMPLETE_DELIVERY' AND o.email = :email GROUP BY DATE(o.createdTime)")
-//    List<BuyerGraphPriceData> findSumPriceByDateBetweenAndStatueAndEmail(@Param("startDate") LocalDateTime startDate, @Param("endDate") LocalDateTime endDate, @Param("email") String email);
-//
-//    @Query("SELECT new com.example.ordering_lecture.order.dto.BuyerGraphCountData(DATE(o.createdTime) as createdTime, COUNT(*) as count) FROM Ordering o WHERE o.createdTime BETWEEN :startDate AND :endDate AND o.statue = 'COMPLETE_DELIVERY' AND o.email = :email GROUP BY DATE(o.createdTime)")
-//    List<BuyerGraphCountData> findCompletedOrdersByEmailAndDateRange(@Param("startDate") LocalDateTime startDate, @Param("endDate") LocalDateTime endDate, @Param("email") String email);
 }

--- a/order/src/main/java/com/example/ordering_lecture/order/service/OrderingService.java
+++ b/order/src/main/java/com/example/ordering_lecture/order/service/OrderingService.java
@@ -6,6 +6,8 @@ import com.example.ordering_lecture.feign.MemberServiceClient;
 import com.example.ordering_lecture.order.dto.*;
 import com.example.ordering_lecture.order.entity.Ordering;
 import com.example.ordering_lecture.order.repository.OrderRepository;
+import com.example.ordering_lecture.orderdetail.dto.BuyerGraphCountData;
+import com.example.ordering_lecture.orderdetail.dto.BuyerGraphPriceData;
 import com.example.ordering_lecture.orderdetail.dto.OrderDetailRequestDto;
 import com.example.ordering_lecture.orderdetail.dto.OrderDetailResponseDto;
 import com.example.ordering_lecture.orderdetail.entity.OrderDetail;
@@ -16,6 +18,7 @@ import com.example.ordering_lecture.redis.RedisService;
 import org.springframework.stereotype.Service;
 
 import javax.transaction.Transactional;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -118,20 +121,20 @@ public class OrderingService {
         }
         return orderResponseDtos;
     }
-//    // 일별 구매 금액을 위한 데이터
-//    public List<BuyerGraphPriceData> getBuyerGraphPriceData(String email) {
-//        LocalDateTime endDate = LocalDateTime.now();
-//        LocalDateTime startDate = endDate.minusWeeks(2);
-//        System.out.println("startDate = " + startDate);
-//        System.out.println("endDate = " + endDate);
-//        return orderRepository.findSumPriceByDateBetweenAndStatueAndEmail(startDate, endDate, email);
-//    }
-//    // 일별 구매 건수를 위한 데이터
-//    public List<BuyerGraphCountData> getBuyerGraphCountData(String email) {
-//        LocalDateTime endDate = LocalDateTime.now();
-//        LocalDateTime startDate = endDate.minusWeeks(2);
-//        return orderRepository.findCompletedOrdersByEmailAndDateRange(startDate, endDate, email);
-//    }
+    // 일별 구매 금액을 위한 데이터
+    public List<BuyerGraphPriceData> getBuyerGraphPriceData(String email) {
+        LocalDateTime endDate = LocalDateTime.now();
+        LocalDateTime startDate = endDate.minusWeeks(2);
+        System.out.println("startDate = " + startDate);
+        System.out.println("endDate = " + endDate);
+        return orderDetailRepository.findSumPriceByDateBetweenAndStatueAndEmail(startDate, endDate, email);
+    }
+    // 일별 구매 건수를 위한 데이터
+    public List<BuyerGraphCountData> getBuyerGraphCountData(String email) {
+        LocalDateTime endDate = LocalDateTime.now();
+        LocalDateTime startDate = endDate.minusWeeks(2);
+        return orderDetailRepository.findCompletedOrdersByEmailAndDateRange(startDate, endDate, email);
+    }
 //    // 일별 판매 금액을 위한 데이터
 //    public List<SellerGraphPriceData> getSellerGraphPriceData(Long sellerId) {
 //        LocalDateTime endDate = LocalDateTime.now();

--- a/order/src/main/java/com/example/ordering_lecture/order/service/OrderingService.java
+++ b/order/src/main/java/com/example/ordering_lecture/order/service/OrderingService.java
@@ -2,14 +2,11 @@ package com.example.ordering_lecture.order.service;
 
 import com.example.ordering_lecture.common.ErrorCode;
 import com.example.ordering_lecture.common.OrTopiaException;
-import com.example.ordering_lecture.feign.MemberServiceClient;
 import com.example.ordering_lecture.order.dto.*;
 import com.example.ordering_lecture.order.entity.Ordering;
 import com.example.ordering_lecture.order.repository.OrderRepository;
-import com.example.ordering_lecture.orderdetail.dto.BuyerGraphCountData;
-import com.example.ordering_lecture.orderdetail.dto.BuyerGraphPriceData;
-import com.example.ordering_lecture.orderdetail.dto.OrderDetailRequestDto;
-import com.example.ordering_lecture.orderdetail.dto.OrderDetailResponseDto;
+import com.example.ordering_lecture.orderdetail.controller.MemberServiceClient;
+import com.example.ordering_lecture.orderdetail.dto.*;
 import com.example.ordering_lecture.orderdetail.entity.OrderDetail;
 import com.example.ordering_lecture.orderdetail.repository.OrderDetailRepository;
 import com.example.ordering_lecture.payment.controller.ItemServiceClient;
@@ -135,16 +132,16 @@ public class OrderingService {
         LocalDateTime startDate = endDate.minusWeeks(2);
         return orderDetailRepository.findCompletedOrdersByEmailAndDateRange(startDate, endDate, email);
     }
-//    // 일별 판매 금액을 위한 데이터
-//    public List<SellerGraphPriceData> getSellerGraphPriceData(Long sellerId) {
-//        LocalDateTime endDate = LocalDateTime.now();
-//        LocalDateTime startDate = endDate.minusWeeks(2);
-//        return orderDetailRepository.findSalesData(startDate, endDate, sellerId);
-//    }
-//    // 일별 판매 건수를 위한 데이터
-//    public List<SellerGraphCountData> getSellerGraphCountData(Long sellerId) {
-//        LocalDateTime endDate = LocalDateTime.now();
-//        LocalDateTime startDate = endDate.minusWeeks(2);
-//        return orderDetailRepository.findSalesDataBySellerIdAndDateRange(startDate, endDate, sellerId);
-//    }
+    // 일별 판매 금액을 위한 데이터
+    public List<SellerGraphPriceData> getSellerGraphPriceData(Long sellerId) {
+        LocalDateTime endDate = LocalDateTime.now();
+        LocalDateTime startDate = endDate.minusWeeks(2);
+        return orderDetailRepository.findSalesData(startDate, endDate, sellerId);
+    }
+    // 일별 판매 건수를 위한 데이터
+    public List<SellerGraphCountData> getSellerGraphCountData(Long sellerId) {
+        LocalDateTime endDate = LocalDateTime.now();
+        LocalDateTime startDate = endDate.minusWeeks(2);
+        return orderDetailRepository.findSalesDataBySellerIdAndDateRange(startDate, endDate, sellerId);
+    }
 }

--- a/order/src/main/java/com/example/ordering_lecture/orderdetail/controller/MemberServiceClient.java
+++ b/order/src/main/java/com/example/ordering_lecture/orderdetail/controller/MemberServiceClient.java
@@ -1,4 +1,4 @@
-package com.example.ordering_lecture.feign;
+package com.example.ordering_lecture.orderdetail.controller;
 
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;

--- a/order/src/main/java/com/example/ordering_lecture/orderdetail/dto/BuyerGraphCountData.java
+++ b/order/src/main/java/com/example/ordering_lecture/orderdetail/dto/BuyerGraphCountData.java
@@ -1,4 +1,4 @@
-package com.example.ordering_lecture.order.dto;
+package com.example.ordering_lecture.orderdetail.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;

--- a/order/src/main/java/com/example/ordering_lecture/orderdetail/dto/BuyerGraphPriceData.java
+++ b/order/src/main/java/com/example/ordering_lecture/orderdetail/dto/BuyerGraphPriceData.java
@@ -1,4 +1,4 @@
-package com.example.ordering_lecture.order.dto;
+package com.example.ordering_lecture.orderdetail.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;

--- a/order/src/main/java/com/example/ordering_lecture/orderdetail/dto/SellerGraphCountData.java
+++ b/order/src/main/java/com/example/ordering_lecture/orderdetail/dto/SellerGraphCountData.java
@@ -1,4 +1,4 @@
-package com.example.ordering_lecture.order.dto;
+package com.example.ordering_lecture.orderdetail.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -7,7 +7,7 @@ import java.util.Date;
 
 @Data
 @AllArgsConstructor
-public class SellerGraphPriceData {
+public class SellerGraphCountData {
     private Date createdTime;
-    private Long price;
+    private Long count;
 }

--- a/order/src/main/java/com/example/ordering_lecture/orderdetail/dto/SellerGraphPriceData.java
+++ b/order/src/main/java/com/example/ordering_lecture/orderdetail/dto/SellerGraphPriceData.java
@@ -1,4 +1,4 @@
-package com.example.ordering_lecture.order.dto;
+package com.example.ordering_lecture.orderdetail.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -7,7 +7,7 @@ import java.util.Date;
 
 @Data
 @AllArgsConstructor
-public class SellerGraphCountData {
+public class SellerGraphPriceData {
     private Date createdTime;
-    private Long count;
+    private Long price;
 }

--- a/order/src/main/java/com/example/ordering_lecture/orderdetail/repository/OrderDetailRepository.java
+++ b/order/src/main/java/com/example/ordering_lecture/orderdetail/repository/OrderDetailRepository.java
@@ -1,7 +1,7 @@
 package com.example.ordering_lecture.orderdetail.repository;
 
-import com.example.ordering_lecture.order.dto.SellerGraphCountData;
-import com.example.ordering_lecture.order.dto.SellerGraphPriceData;
+import com.example.ordering_lecture.orderdetail.dto.BuyerGraphCountData;
+import com.example.ordering_lecture.orderdetail.dto.BuyerGraphPriceData;
 import com.example.ordering_lecture.orderdetail.entity.OrderDetail;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -15,7 +15,14 @@ import java.util.List;
 public interface OrderDetailRepository extends JpaRepository<OrderDetail,Long> {
     List<OrderDetail> findAllByOrderingId(Long orderId);
 
-//    @Query("SELECT new com.example.ordering_lecture.order.dto.SellerGraphPriceData(DATE(od.createdTime) as createdTime, SUM(od.discountPrice) as price) FROM OrderDetail od JOIN od.ordering o WHERE o.statue = 'COMPLETE_DELIVERY' AND od.sellerId = :sellerId AND od.createdTime BETWEEN :startDate AND :endDate GROUP BY DATE(od.createdTime)")
+    @Query("SELECT new com.example.ordering_lecture.orderdetail.dto.BuyerGraphPriceData(DATE(o.createdTime) as createdTime, SUM(od.discountPrice) as price) FROM OrderDetail od JOIN od.ordering o WHERE od.statue = 'COMPLETE_DELIVERY' AND od.createdTime BETWEEN :startDate AND :endDate AND o.email = :email GROUP BY DATE(o.createdTime)\n")
+    List<BuyerGraphPriceData> findSumPriceByDateBetweenAndStatueAndEmail(@Param("startDate") LocalDateTime startDate, @Param("endDate") LocalDateTime endDate, @Param("email") String email);
+
+    @Query("SELECT new com.example.ordering_lecture.orderdetail.dto.BuyerGraphCountData(DATE(o.createdTime) as createdTime, COUNT(*) as count) FROM OrderDetail od JOIN od.ordering o WHERE od.statue = 'COMPLETE_DELIVERY' AND o.createdTime BETWEEN :startDate AND :endDate AND o.email = :email GROUP BY DATE(od.createdTime)")
+    List<BuyerGraphCountData> findCompletedOrdersByEmailAndDateRange(@Param("startDate") LocalDateTime startDate, @Param("endDate") LocalDateTime endDate, @Param("email") String email);
+
+
+//    @Query("SELECT new com.example.ordering_lecture.orderdetail.dto.SellerGraphPriceData(DATE(od.createdTime) as createdTime, SUM(od.discountPrice) as price) FROM OrderDetail od JOIN od.ordering o WHERE o.statue = 'COMPLETE_DELIVERY' AND od.sellerId = :sellerId AND od.createdTime BETWEEN :startDate AND :endDate GROUP BY DATE(od.createdTime)")
 //    List<SellerGraphPriceData> findSalesData(@Param("startDate") LocalDateTime startDate, @Param("endDate") LocalDateTime endDate, @Param("sellerId") Long sellerId);
 //
 //    @Query("SELECT new com.example.ordering_lecture.order.dto.SellerGraphCountData(DATE(od.createdTime) as createdTime, COUNT(*) as count) FROM OrderDetail od JOIN od.ordering o WHERE o.statue = 'COMPLETE_DELIVERY' AND od.sellerId = :sellerId AND od.createdTime BETWEEN :startDate AND :endDate GROUP BY DATE(od.createdTime)")

--- a/order/src/main/java/com/example/ordering_lecture/orderdetail/repository/OrderDetailRepository.java
+++ b/order/src/main/java/com/example/ordering_lecture/orderdetail/repository/OrderDetailRepository.java
@@ -2,6 +2,8 @@ package com.example.ordering_lecture.orderdetail.repository;
 
 import com.example.ordering_lecture.orderdetail.dto.BuyerGraphCountData;
 import com.example.ordering_lecture.orderdetail.dto.BuyerGraphPriceData;
+import com.example.ordering_lecture.orderdetail.dto.SellerGraphCountData;
+import com.example.ordering_lecture.orderdetail.dto.SellerGraphPriceData;
 import com.example.ordering_lecture.orderdetail.entity.OrderDetail;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -21,10 +23,9 @@ public interface OrderDetailRepository extends JpaRepository<OrderDetail,Long> {
     @Query("SELECT new com.example.ordering_lecture.orderdetail.dto.BuyerGraphCountData(DATE(o.createdTime) as createdTime, COUNT(*) as count) FROM OrderDetail od JOIN od.ordering o WHERE od.statue = 'COMPLETE_DELIVERY' AND o.createdTime BETWEEN :startDate AND :endDate AND o.email = :email GROUP BY DATE(od.createdTime)")
     List<BuyerGraphCountData> findCompletedOrdersByEmailAndDateRange(@Param("startDate") LocalDateTime startDate, @Param("endDate") LocalDateTime endDate, @Param("email") String email);
 
+    @Query("SELECT new com.example.ordering_lecture.orderdetail.dto.SellerGraphPriceData(DATE(od.createdTime) as createdTime, SUM(od.discountPrice) as price) FROM OrderDetail od WHERE od.statue = 'COMPLETE_DELIVERY' AND od.sellerId = :sellerId AND od.createdTime BETWEEN :startDate AND :endDate GROUP BY DATE(od.createdTime)")
+    List<SellerGraphPriceData> findSalesData(@Param("startDate") LocalDateTime startDate, @Param("endDate") LocalDateTime endDate, @Param("sellerId") Long sellerId);
 
-//    @Query("SELECT new com.example.ordering_lecture.orderdetail.dto.SellerGraphPriceData(DATE(od.createdTime) as createdTime, SUM(od.discountPrice) as price) FROM OrderDetail od JOIN od.ordering o WHERE o.statue = 'COMPLETE_DELIVERY' AND od.sellerId = :sellerId AND od.createdTime BETWEEN :startDate AND :endDate GROUP BY DATE(od.createdTime)")
-//    List<SellerGraphPriceData> findSalesData(@Param("startDate") LocalDateTime startDate, @Param("endDate") LocalDateTime endDate, @Param("sellerId") Long sellerId);
-//
-//    @Query("SELECT new com.example.ordering_lecture.order.dto.SellerGraphCountData(DATE(od.createdTime) as createdTime, COUNT(*) as count) FROM OrderDetail od JOIN od.ordering o WHERE o.statue = 'COMPLETE_DELIVERY' AND od.sellerId = :sellerId AND od.createdTime BETWEEN :startDate AND :endDate GROUP BY DATE(od.createdTime)")
-//    List<SellerGraphCountData> findSalesDataBySellerIdAndDateRange(@Param("startDate") LocalDateTime startDate, @Param("endDate") LocalDateTime endDate, @Param("sellerId") Long sellerId);
+    @Query("SELECT new com.example.ordering_lecture.orderdetail.dto.SellerGraphCountData(DATE(od.createdTime) as createdTime, COUNT(*) as count) FROM OrderDetail od WHERE od.statue = 'COMPLETE_DELIVERY' AND od.sellerId = :sellerId AND od.createdTime BETWEEN :startDate AND :endDate GROUP BY DATE(od.createdTime)")
+    List<SellerGraphCountData> findSalesDataBySellerIdAndDateRange(@Param("startDate") LocalDateTime startDate, @Param("endDate") LocalDateTime endDate, @Param("sellerId") Long sellerId);
 }

--- a/order/src/main/java/com/example/ordering_lecture/payment/controller/ItemServiceClient.java
+++ b/order/src/main/java/com/example/ordering_lecture/payment/controller/ItemServiceClient.java
@@ -12,6 +12,8 @@ import java.util.List;
 public interface ItemServiceClient {
     @PostMapping("item/search/optionDetailId/{itemId}")
     Long searchIdByOptionDetail(@PathVariable(name = "itemId") Long itemId,@RequestBody List<String> values);
-    @GetMapping(value="item/{itemId}/itemName")
-    String findNameById(@PathVariable("itemId") Long itemId);
+    @PostMapping("item/{itemId}/itemName")
+    String findNameById(@PathVariable(name="itemId") Long itemId);
+
+
 }


### PR DESCRIPTION
## :: 최근 작업 주제
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 

- statue 컬럼이 Order에서 OrderDetail로 이동함에 따라, 기존 그래프 시각화 코드를 수정

## :: 구현 사항 설명 
- 일별 구매 및 판매 그래프는 구매 금액/판매 금액의 차이가 클수록 꺾은선 그래프가 어울리지 않는다는 멘토님의 말씀을 듣고 막대 그래프로 수정하였습니다.
- 기존 막대 그래프였던 구매 및 판매 건수 그래프를 도넛 차트로 변경하였습니다.

<br />

## :: Issue 포인트 

- Feign 통신 시, 모든 세팅을 잘 해줬지만 아래 오류가 발생했습니다.
- 방법을 찾다가, 단순히 @GetMapping을 @PostMapping으로 변경했더니 해결되었습니다.
- 정확히 왜 해결됐는지 추가적인 이해가 필요합니다...


<br />

## :: 기타 질문 및 특이 사항

- 판매자 페이지에 여러 그래프를 추가하면 좋을 것 같습니다.
(1) 판매자 별로, 어떤 연령대가 많이 구매 했는지 보여주는 그래프
(2) 판매자 별로, 어떤 성별이 많이 구매 했는지 보여주는 그래프
